### PR TITLE
Target fixes & improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [2.0.1] - 2021-07-02
+
 ### Addedd
 - DCAT Target support
 
@@ -82,6 +84,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Make wrapper available via require.
 
+[2.0.1]: https://github.com/RMLio/rmlmapper-java-wrapper-js/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/RMLio/rmlmapper-java-wrapper-js/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/RMLio/rmlmapper-java-wrapper-js/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/RMLio/rmlmapper-java-wrapper-js/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Addedd
+- DCAT Target support
+
+### Fixed
+- DCAT and VoID Datasets expect an IRI for {dcat, void}:dataDump
+
 ## [2.0.0] - 2021-06-28
 
 ### Added

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -327,7 +327,7 @@ class RMLMapperWrapper {
           const filename = path.basename(voidDataDumps[0].value);
 
           const p = dirPrefix + filename;
-          store.addQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), literal('file://' + p));
+          store.addQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), namedNode('file://' + p));
           store.removeQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), voidDataDumps[0]);
 
           targetFiles.push(p);
@@ -335,7 +335,7 @@ class RMLMapperWrapper {
           const filename = path.basename(dcatDataDumps[0].value);
 
           const p = dirPrefix + filename;
-          store.addQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), literal('file://' + p));
+          store.addQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), namedNode('file://' + p));
           store.removeQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), dcatDataDumps[0]);
 
           targetFiles.push(p);

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -320,14 +320,23 @@ class RMLMapperWrapper {
 
       if (targetNodes.length > 0) {
         const targetNode = targetNodes[0];
-        const dataDumps = store.getObjects(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'));
+        const voidDataDumps = store.getObjects(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'));
+        const dcatDataDumps = store.getObjects(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'));
 
-        if (dataDumps.length > 0) {
-          const filename = path.basename(dataDumps[0].value);
+        if (voidDataDumps.length > 0) {
+          const filename = path.basename(voidDataDumps[0].value);
 
           const p = dirPrefix + filename;
           store.addQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), literal('file://' + p));
-          store.removeQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), dataDumps[0]);
+          store.removeQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), voidDataDumps[0]);
+
+          targetFiles.push(p);
+        } else if (dcatDataDumps.length > 0) {
+          const filename = path.basename(dcatDataDumps[0].value);
+
+          const p = dirPrefix + filename;
+          store.addQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), literal('file://' + p));
+          store.removeQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), dcatDataDumps[0]);
 
           targetFiles.push(p);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rmlio/rmlmapper-java-wrapper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rmlio/rmlmapper-java-wrapper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A JavaScript wrapper around the Java RMLMapper.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add DCAT Target support
- Use IRI instead of literal for `void:dataDump` and `dcat:dataDump`