### PR TITLE
Fix for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Bug causing invalid paths in RML on windows
+
 ## [2.0.1] - 2021-07-02
 
 ### Added

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -134,6 +134,8 @@ class RMLMapperWrapper {
 
     return new Promise((resolve, reject) => {
       exec(execCommand, async (error, stdout, stderr) => {
+        console.log(execCommand)
+        console.log(stderr)
         if (stderr) {
           await fs.writeFile(logFile, stderr);
           const err = new Error(`Error while executing the rules.`);
@@ -295,7 +297,7 @@ class RMLMapperWrapper {
   }
 
   /**
-   * Paths in the RML files can't have \\ so all / must be replaced by \, for windows, the mapper takes care of reverting this again.
+   * Paths in the RML files can't have \\ so all \ must be replaced by /, for windows, the mapper takes care of reverting this again.
    */
   _fixPath(filePath) {
     return path.sep === '\\' ? filePath.replace(/\\/g, '/') : filePath;

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -134,8 +134,6 @@ class RMLMapperWrapper {
 
     return new Promise((resolve, reject) => {
       exec(execCommand, async (error, stdout, stderr) => {
-        console.log(execCommand)
-        console.log(stderr)
         if (stderr) {
           await fs.writeFile(logFile, stderr);
           const err = new Error(`Error while executing the rules.`);
@@ -297,7 +295,7 @@ class RMLMapperWrapper {
   }
 
   /**
-   * Paths in the RML files can't have \\ so all \ must be replaced by /, for windows, the mapper takes care of reverting this again.
+   * Paths in the RML files can't have \\ so all \ must be replaced by /, for Windows, the RMLMapper takes care of reverting this again.
    */
   _fixPath(filePath) {
     return path.sep === '\\' ? filePath.replace(/\\/g, '/') : filePath;

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -297,8 +297,8 @@ class RMLMapperWrapper {
   /**
    * Paths in the RML files can't have \\ so all / must be replaced by \, for windows, the mapper takes care of reverting this again.
    */
-  _fixPath(path) {
-    return path.replace(/\\/g, '/');
+  _fixPath(filePath) {
+    return path.sep === '\\' ? filePath.replace(/\\/g, '/') : filePath;
   }
 
   _updateTargetsWithLocalFiles(options = {}) {

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -72,8 +72,8 @@ class RMLMapperWrapper {
       await fs.mkdir(processDir);
 
       const logFile = path.join(processDir, 'rmlmapper.log');
-      const sourceDirPrefix = path.join(processDir, sourceFilePrefix);
-      const targetDirPrefix = path.join(processDir, targetFilePrefix);
+      const sourceDirPrefix =this._fixPath(path.join(processDir, sourceFilePrefix));
+      const targetDirPrefix = this._fixPath(path.join(processDir, targetFilePrefix));
 
       if (options.sources) {
         await this._saveSources(options.sources, sourceDirPrefix);
@@ -96,7 +96,7 @@ class RMLMapperWrapper {
 
   async _executeCLI(options) {
     let {rml, sourceDirPrefix, processDir, logFile, serialization, asQuads, generateMetadata, fno, targetDirPrefix} = options;
-    const mappingFile = path.join(processDir, 'mapping.rml.ttl');
+    const mappingFile = this._fixPath(path.join(processDir, 'mapping.rml.ttl'));
     let functionsFile;
 
     const result = this._updateTargetsWithLocalFiles({rmlQuads: rml, dirPrefix: targetDirPrefix});
@@ -106,7 +106,7 @@ class RMLMapperWrapper {
 
     await fs.writeFile(mappingFile, rmlStr);
     const outputFile = path.join(processDir, "output." + serialization);
-    const metadataFile = path.join(processDir, "metadata." + serialization);
+    const metadataFile = this._fixPath(path.join(processDir, "metadata." + serialization));
 
     if (fno) {
       functionsFile = path.join(processDir, 'functions.ttl');
@@ -294,6 +294,13 @@ class RMLMapperWrapper {
     return serialization.replace(/[-_]/g, '');
   }
 
+  /**
+   * Paths in the RML files can't have \\ so all / must be replaced by \, for windows, the mapper takes care of reverting this again.
+   */
+  _fixPath(path) {
+    return path.replace(/\\/g, '/');
+  }
+
   _updateTargetsWithLocalFiles(options = {}) {
     let {rmlQuads, dirPrefix} = options;
     const targetFiles = [];
@@ -326,25 +333,29 @@ class RMLMapperWrapper {
         if (voidDataDumps.length > 0) {
           const filename = path.basename(voidDataDumps[0].value);
 
-          const p = dirPrefix + filename;
+          let p = dirPrefix + filename;
+          targetFiles.push(p);
+          p = this._fixPath(p);
+
           store.addQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), namedNode('file://' + p));
           store.removeQuad(targetNode, namedNode('http://rdfs.org/ns/void#dataDump'), voidDataDumps[0]);
 
-          targetFiles.push(p);
         } else if (dcatDataDumps.length > 0) {
           const filename = path.basename(dcatDataDumps[0].value);
 
-          const p = dirPrefix + filename;
+          let p = dirPrefix + filename;
+          targetFiles.push(p);
+          p = this._fixPath(p);
+
           store.addQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), namedNode('file://' + p));
           store.removeQuad(targetNode, namedNode('http://www.w3.org/ns/dcat#dataDump'), dcatDataDumps[0]);
-
-          targetFiles.push(p);
         }
       }
     });
 
     return {rml: store.getQuads(), targetFiles};
   }
+
 }
 
 module.exports = RMLMapperWrapper;


### PR DESCRIPTION
This fixes a problem where paths in windows would become double backslashes in the generated RML files, this is not allowed in RML URI causing RMLMapper to crash.