### PR TITLE
better error handling when stderr is non-empty but also doesn't conta…

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -150,6 +150,8 @@ class RMLMapperWrapper {
 
     return new Promise((resolve, reject) => {
       const mapping = spawn(execCommand, execParams, {
+        // setting CWD when you have a mapping file that accesses (large) files directly
+        // so you don't need to needlessly copy that file
         cwd: path.resolve(processDir, '../../')
       });
       let stdout = '';


### PR DESCRIPTION
…in errors

Using spawn instead of exec fixes multiple things:

- paths with spaces -> no problem
- stderr buffer overflow -> no exec error
- when rmlmapper gives stderr that doesn't contain an actual error -> no problem