### PR TITLE
Wrapped path of outputFile in fixPath

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -112,7 +112,7 @@ class RMLMapperWrapper {
     const rmlStr = await this._setSourcesInRMLRules(rml, sourceDirPrefix, sources);
 
     await fs.writeFile(mappingFile, rmlStr);
-    const outputFile = path.join(processDir, "output." + serialization);
+    const outputFile = this._fixPath(path.join(processDir, "output." + serialization));
     const metadataFile = this._fixPath(path.join(processDir, "metadata." + serialization));
 
     if (fno) {


### PR DESCRIPTION
Fixes usage of rmlmapper-wrapper on windows. 
3 tests remain broken (Parameter: functions, Single target, Two targets), which also fail on mac. 